### PR TITLE
Use a docker secret to pass in a PAT for installing private npm packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ If it's a tagged version (vX.Y.Z), an action event is dispatched to the Operatio
           registry-server: ${{ secrets.REGISTRY_LOGIN_SERVER }}
           registry-user: ${{ secrets.REGISTRY_USERNAME }}
           registry-pass: ${{ secrets.REGISTRY_PASSWORD }}
+          npm-token: ${{ secrets.NPM_TOKEN }}
 ```
 
 ### Inputs
@@ -26,7 +27,7 @@ If it's a tagged version (vX.Y.Z), an action event is dispatched to the Operatio
 | `registry-server` | (**required**) Docker registry location/URL |  |
 | `registry-user` | (**required**) Docker registry username for authentication |  |
 | `registry-pass` | (**required**) Docker registry password for authentication |  |
-| `backfeed-repo-token` | Github access token for use inside the docker build |  |
+| `npm-token` | Github access token (PAT) to access private npm packages |  |
 
 ### Outputs
 | Name | Description |

--- a/action.yml
+++ b/action.yml
@@ -14,9 +14,9 @@ inputs:
   registry-pass:
     description: "Docker registry password"
     required: true
-  backfeed-repo-token:
-    description: "Github token to passthrough docker build to access current repo"
+  npm-token:
     required: false
+    description: "Access token for private (npm) packages."
 outputs:
   version:
     description: "Version string generated for the image."
@@ -57,11 +57,22 @@ runs:
         username: ${{ inputs.registry-user }}
         password: ${{ inputs.registry-pass }}
 
+    - name: "Github packages authorization"
+      uses: actions/setup-node@v2
+      with:
+        registry-url: 'https://npm.pkg.github.com'
+        scope: '@OdysseyMomentumExperience'
+        token: ${{ inputs.npm-token }}
+
     - name: "Build and push image"
       env:
         IMAGE: ${{ inputs.registry-server }}/${{ inputs.image-name }}
+        DOCKER_BUILDKIT: 1
       shell: bash
       run: |
-        docker build --build-arg GITHUB_TOKEN=${{ inputs.backfeed-repo-token }} -f Dockerfile . -t ${IMAGE}:${{ github.sha }} -t ${IMAGE}:${VERSION}
+        docker build \
+          --secret id=npm,src=$NPM_CONFIG_USERCONFIG \
+          -t ${IMAGE}:${{ github.sha }} -t ${IMAGE}:${VERSION} \
+          -f Dockerfile .
         docker push ${IMAGE}:${{ github.sha }}
         docker push ${IMAGE}:${VERSION}


### PR DESCRIPTION
Backwards incompatible since we drop the 'backfeed' token that was used for ssh access.